### PR TITLE
No need to represent $Discussions array as string when unsetting

### DIFF
--- a/models/class.actedmodel.php
+++ b/models/class.actedmodel.php
@@ -85,7 +85,7 @@ class ActedModel extends Gdn_Model {
     foreach($Discussions as $Discussion) {
       $DiscussionsByID[$Discussion['DiscussionID']] = $Discussion;
     }
-    unset(${$Discussions});
+    unset($Discussions);
 
     foreach($Comments as &$Comment) {
       $Comment['Discussion'] = $DiscussionsByID[$Comment['DiscussionID']];


### PR DESCRIPTION
Is there a specific reason as to why you didn't just unset it as-is?
