### PR TITLE
Correctly distinguish between parent types to avoid ID clashes in the Acted Model

### DIFF
--- a/models/class.actedmodel.php
+++ b/models/class.actedmodel.php
@@ -30,6 +30,7 @@ class ActedModel extends Gdn_Model {
                       ->Join('Reaction r', 'd.DiscussionID = r.ParentID')
                       ->Where('d.InsertUserID', $UserID)
                       ->Where('r.ActionID', $ActionID)
+                      ->Where('r.ParentType', 'discussion')
                       ->OrderBy('r.DateInserted', 'DESC')
                       ->Get()->Result(DATASET_TYPE_ARRAY);
 
@@ -39,6 +40,7 @@ class ActedModel extends Gdn_Model {
                       ->Join('Reaction r', 'c.CommentID = r.ParentID')
                       ->Where('c.InsertUserID', $UserID)
                       ->Where('r.ActionID', $ActionID)
+                      ->Where('r.ParentType', 'comment')
                       ->OrderBy('r.DateInserted', 'DESC')
                       ->Get()->Result(DATASET_TYPE_ARRAY);
 


### PR DESCRIPTION
When selecting content that has been reacted to, discussion and comment IDs will currently clash. E.g. if comment 16 has been reacted to, the Acted Model will also query discussion 16 if it exists.

This PR fixes the bug by taking into account the reaction parent types. The data was already available but wasn't being used.
