### PR TITLE
Fixed misspelling

### DIFF
--- a/settings/about.php
+++ b/settings/about.php
@@ -18,7 +18,7 @@ $ApplicationInfo['Yaga'] = array(
     // Application-specific permissions
     'RegisterPermissions'  => array(
         'Yaga.Reactions.Add',    // Can a user click on reactions?
-        'Yaga.Reactions.Manage', // Can a user add/edit/delete actions?
+        'Yaga.Reactions.Manage', // Can a user add/edit/delete reactions?
         'Yaga.Reactions.View',   // Can a user see reactions?
         'Yaga.Reactions.Edit',   // Can a user remove other's reactions?
         'Yaga.Badges.Add',       // Can a user give out badges?


### PR DESCRIPTION
I have seen a misspelling in the about.php where the comment next to the Yaga.Reactions.Manage permission is: "Can a user add/edit/delete actions?" where it should be "Can a user add/edit/delete reactions?". This is just a minor pull request.
