### PR TITLE
Limiting the reactions UserRhoto renders.

### DIFF
--- a/library/functions.render.php
+++ b/library/functions.render.php
@@ -55,7 +55,17 @@ if(!function_exists('RenderReactionRecord')) {
 
   function RenderReactionRecord($ID, $Type) {
     $Reactions = Yaga::ReactionModel()->GetRecord($ID, $Type);
+    $i = 0;
+    $result = count($Reactions);
     foreach($Reactions as $Reaction) {
+    	if($i > 4) {
+    		$i++;
+    		if ($i == $result) {
+    			$actionName = $Reaction->Name;
+    			$counted = $result-5;
+    			echo ' and '.$counted.' other'.($counted>1?'s':'').' '.strtolower($actionName).' this.';
+    		}
+    	} else {
       $User = Gdn::UserModel()->GetID($Reaction->UserID);
 	  $DateTitle = $User->Name . ' - ' . $Reaction->Name . ' on ' . Gdn_Format::Date($Reaction->DateInserted, '%B %e, %Y');
       $String = UserPhoto($User, array('Size' => 'Small', 'title' => $DateTitle));
@@ -66,6 +76,8 @@ if(!function_exists('RenderReactionRecord')) {
           'title' => $DateTitle
       );
       echo Wrap($String, 'span', $Wrapttributes);
+      $i++;
+    	}
     }
   }
 


### PR DESCRIPTION
Sorts through and renders the avatars for up to 5 reactions, then calculates the remaining reactions and refers the reaction name by name. Out put example "[:D][:D][:D][:D][:D] and 8 others like this."
