### PR TITLE
Show the right page number on profile/reactions

### DIFF
--- a/models/class.actedmodel.php
+++ b/models/class.actedmodel.php
@@ -250,6 +250,25 @@ class ActedModel extends Gdn_Model {
   }
 
   /**
+   * Return the count of reactions received by a user for distinct ParentIDs
+   *
+   * @param int $UserID
+   * @param int $ActionID
+   * @return int
+   */
+  public function GetUserCount($UserID, $ActionID) {
+    $Result = $this->SQL
+            ->Select('COUNT(DISTINCT ParentID)', '', 'Count')
+            ->From('Reaction')
+            ->Where('ActionID', $ActionID)
+            ->Where('ParentAuthorID', $UserID)
+            ->Get()
+            ->FirstRow();
+
+    return $Result === FALSE ? 0 : $Result->Count;
+  }
+
+  /**
    * Returns a list of all recent scored posts ordered by date reacted
    * 
    * @param int $Limit

--- a/settings/class.hooks.php
+++ b/settings/class.hooks.php
@@ -184,7 +184,7 @@ class YagaHooks implements Gdn_IPlugin {
     $Sender->Pager = $PagerFactory->GetPager('Pager', $Sender);
     $Sender->Pager->ClientID = 'Pager';
     $Sender->Pager->Configure(
-            $Offset, $Limit, $ReactionModel->GetUserCount($Sender->User->UserID, $ActionID), 'profile/reactions/' . $Sender->User->UserID . '/' . Gdn_Format::Url($Sender->User->Name) . '/' . $ActionID . '/%1$s/'
+            $Offset, $Limit, $Model->GetUserCount($Sender->User->UserID, $ActionID), 'profile/reactions/' . $Sender->User->UserID . '/' . Gdn_Format::Url($Sender->User->Name) . '/' . $ActionID . '/%1$s/'
     );
 
     // Render the ProfileController


### PR DESCRIPTION
The pager in Profile/Reactions shows too many pages.
If a user receives 20 reactions of the same type on 10 items, the pager shows 4 pages instead of 2 because using ReactionModel::GetUserCount() doesn't take into account that reactions on the same item are merged.

I introduced ActedModel::GetUserCount() which counts distinct items.

Unfortunately, the count may be too low in rare cases (similar DiscussionID and PostID), because Select('COUNT(DISTINCT ParentID, ParentType)') doesn't work with the SqlDriver.

Maybe you know a better solution.

Edit: A Prev/Next pager may be better performance wise.