### PR TITLE
Show MeMenu profile picture in full size

### DIFF
--- a/design/badges.css
+++ b/design/badges.css
@@ -24,7 +24,8 @@
 }
 
 /* Badge detail page */
-.ProfilePhotoMedium {
+.Box .ProfilePhotoMedium,
+.ContentColumn .ProfilePhotoMedium {
   height: 24px;
   margin-bottom: 3px;
   margin-right: 3px;


### PR DESCRIPTION
Changing .ProfilePhotoMedium also changes the picture size in the
MeMenu/MeBox.

This restricts the rule to panel boxes and the main content column.