### PR TITLE
Fix profile/reactions pager

### DIFF
--- a/models/class.actedmodel.php
+++ b/models/class.actedmodel.php
@@ -50,9 +50,10 @@ class ActedModel extends Gdn_Model {
    * @param int $ActionID
    * @param int $Limit
    * @param int $Offset
+   * @param int &$TotalRecords
    * @return array
    */
-  public function Get($UserID, $ActionID, $Limit = NULL, $Offset = 0) {
+  public function Get($UserID, $ActionID, $Limit = NULL, $Offset = 0, &$TotalRecords = 0) {
     $CacheKey = "yaga.profile.reactions.{$UserID}.{$ActionID}";
     $Content = Gdn::Cache()->Get($CacheKey);
 
@@ -92,6 +93,7 @@ class ActedModel extends Gdn_Model {
     }
 
     $this->Security($Content);
+    $TotalRecords = count($Content);
     $this->Condense($Content, $Limit, $Offset);
 
     return $Content;
@@ -105,9 +107,10 @@ class ActedModel extends Gdn_Model {
    * @param int $ActionID
    * @param int $Limit
    * @param int $Offset
+   * @param int &$TotalRecords
    * @return array
    */
-  public function GetTaken($UserID, $ActionID, $Limit = NULL, $Offset = 0) {
+  public function GetTaken($UserID, $ActionID, $Limit = NULL, $Offset = 0, &$TotalRecords = 0) {
     $CacheKey = "yaga.profile.actions.{$UserID}.{$ActionID}";
     $Content = Gdn::Cache()->Get($CacheKey);
 
@@ -147,6 +150,7 @@ class ActedModel extends Gdn_Model {
     }
 
     $this->Security($Content);
+    $TotalRecords = count($Content);
     $this->Condense($Content, $Limit, $Offset);
 
     return $Content;
@@ -159,9 +163,10 @@ class ActedModel extends Gdn_Model {
    * @param int $ActionID
    * @param int $Limit
    * @param int $Offset
+   * @param int &$TotalRecords
    * @return array
    */
-  public function GetAction($ActionID, $Limit = NULL, $Offset = 0) {
+  public function GetAction($ActionID, $Limit = NULL, $Offset = 0, &$TotalRecords = 0) {
     $CacheKey = "yaga.best.actions.{$ActionID}";
     $Content = Gdn::Cache()->Get($CacheKey);
 
@@ -199,6 +204,7 @@ class ActedModel extends Gdn_Model {
     }
 
     $this->Security($Content);
+    $TotalRecords = count($Content);
     $this->Condense($Content, $Limit, $Offset);
 
     return $Content;
@@ -210,9 +216,10 @@ class ActedModel extends Gdn_Model {
    * @param int $UserID
    * @param int $Limit
    * @param int $Offset
+   * @param int &$TotalRecords
    * @return array
    */
-  public function GetBest($UserID = NULL, $Limit = NULL, $Offset = 0) {
+  public function GetBest($UserID = NULL, $Limit = NULL, $Offset = 0, &$TotalRecords = 0) {
     $CacheKey = "yaga.profile.best.{$UserID}";
     $Content = Gdn::Cache()->Get($CacheKey);
 
@@ -244,6 +251,7 @@ class ActedModel extends Gdn_Model {
     }
 
     $this->Security($Content);
+    $TotalRecords = count($Content);
     $this->Condense($Content, $Limit, $Offset);
 
     return $Content;
@@ -254,9 +262,10 @@ class ActedModel extends Gdn_Model {
    * 
    * @param int $Limit
    * @param int $Offset
+   * @param int &$TotalRecords
    * @return array
    */
-  public function GetRecent($Limit = NULL, $Offset = 0) {
+  public function GetRecent($Limit = NULL, $Offset = 0, &$TotalRecords = 0) {
     $CacheKey = 'yaga.best.recent';
     $Content = Gdn::Cache()->Get($CacheKey);
 
@@ -293,6 +302,7 @@ class ActedModel extends Gdn_Model {
     }
 
     $this->Security($Content);
+    $TotalRecords = count($Content);
     $this->Condense($Content, $Limit, $Offset);
 
     return $Content;

--- a/settings/class.hooks.php
+++ b/settings/class.hooks.php
@@ -163,7 +163,7 @@ class YagaHooks implements Gdn_IPlugin {
     $Sender->AddDefinition('CollapseText', T('(less)'));
 
     $Model = new ActedModel();
-    $Data = $Model->Get($Sender->User->UserID, $ActionID, $Limit, $Offset);
+    $Data = $Model->Get($Sender->User->UserID, $ActionID, $Limit, $Offset, $TotalRecords);
 
     $Sender->SetData('Content', $Data);
 
@@ -177,14 +177,12 @@ class YagaHooks implements Gdn_IPlugin {
       $Sender->Head->AddTag('meta', array('name' => 'robots', 'content' => 'noindex,noarchive'));
     }
 
-    $ReactionModel = Yaga::ReactionModel();
-
     // Build a pager
     $PagerFactory = new Gdn_PagerFactory();
     $Sender->Pager = $PagerFactory->GetPager('Pager', $Sender);
     $Sender->Pager->ClientID = 'Pager';
     $Sender->Pager->Configure(
-            $Offset, $Limit, $ReactionModel->GetUserCount($Sender->User->UserID, $ActionID), 'profile/reactions/' . $Sender->User->UserID . '/' . Gdn_Format::Url($Sender->User->Name) . '/' . $ActionID . '/%1$s/'
+            $Offset, $Limit, $TotalRecords, 'profile/reactions/' . $Sender->User->UserID . '/' . Gdn_Format::Url($Sender->User->Name) . '/' . $ActionID . '/%1$s/'
     );
 
     // Render the ProfileController


### PR DESCRIPTION
This adds a TotalCounts parameter to all ActedModel Get* functions which is passed by reference.
Since these functions always fetch the whole result set (or get it from the cache), they might as well return its size.
This also gets rid of a count query.