### PR TITLE
Implement Reaction memory cache

### DIFF
--- a/models/class.reactionmodel.php
+++ b/models/class.reactionmodel.php
@@ -76,7 +76,7 @@ class ReactionModel extends Gdn_Model {
       return self::$_Reactions[$Type . $ID];
     }
     else if (in_array($Type, array('discussion', 'comment', 'activity')) && $ID > 0) {
-      return $this->SQL
+      $Result = $this->SQL
               ->Select('a.*, r.InsertUserID as UserID, r.DateInserted')
               ->From('Action a')
               ->Join('Reaction r', 'a.ActionID = r.ActionID')
@@ -85,6 +85,8 @@ class ReactionModel extends Gdn_Model {
               ->OrderBy('r.DateInserted')
               ->Get()
               ->Result();
+      self::$_Reactions[$Type . $ID] = $Result;
+      return $Result;
     }
     else {
       return NULL;

--- a/models/class.reactionmodel.php
+++ b/models/class.reactionmodel.php
@@ -35,6 +35,23 @@ class ReactionModel extends Gdn_Model {
    */
   public function GetList($ID, $Type) {
     $Px = $this->Database->DatabasePrefix;
+
+    // try getting the record count from the cache
+    if (array_key_exists($Type . $ID, self::$_Reactions)) {
+      $Reactions = self::$_Reactions[$Type . $ID];
+      $Actions = Yaga::ActionModel()->Get();
+      // add the count
+      foreach ($Actions as &$Action) {
+        $Action->Count = 0;
+        foreach ($Reactions as $Reaction) {
+          if ($Reaction->ActionID == $Action->ActionID) {
+            $Action->Count++;
+          }
+        }
+      }
+      return $Actions;
+    }
+
     $Sql = "select a.*, "
             . "(select count(r.ReactionID) "
             . "from {$Px}Reaction as r "
@@ -45,6 +62,7 @@ class ReactionModel extends Gdn_Model {
 
     return $this->Database->Query($Sql, array(':ParentID' => $ID, ':ParentType' => $Type))->Result();
   }
+
   /**
    * Returns the reaction records associated with the specified user content.
    *
@@ -53,7 +71,11 @@ class ReactionModel extends Gdn_Model {
    * @return mixed DataSet if it exists, NULL otherwise
    */
   public function GetRecord($ID, $Type) {
-    if(in_array($Type, array('discussion', 'comment', 'activity')) && $ID > 0) {
+    // try getting the record from the cache
+    if (array_key_exists($Type . $ID, self::$_Reactions)) {
+      return self::$_Reactions[$Type . $ID];
+    }
+    else if (in_array($Type, array('discussion', 'comment', 'activity')) && $ID > 0) {
       return $this->SQL
               ->Select('a.*, r.InsertUserID as UserID, r.DateInserted')
               ->From('Action a')
@@ -190,6 +212,34 @@ class ReactionModel extends Gdn_Model {
     $EventArgs['Points'] = $Points;
     $this->FireEvent('AfterReactionSave', $EventArgs);
     return $Reaction;
+  }
+
+  /**
+   * Fills the memory cache with the specified reaction records
+   *
+   * @param string $Type
+   * @param array $IDs
+   */
+  public function Prefetch($Type, $IDs) {
+    if (in_array($Type, array('discussion', 'comment', 'activity')) && !empty($IDs)) {
+      $Result = $this->SQL
+        ->Select('a.*, r.InsertUserID as UserID, r.DateInserted, r.ParentID')
+        ->From('Action a')
+        ->Join('Reaction r', 'a.ActionID = r.ActionID')
+        ->WhereIn('r.ParentID', $IDs)
+        ->Where('r.ParentType', $Type)
+        ->OrderBy('r.DateInserted')
+        ->Get()
+        ->Result();
+      
+      foreach ($IDs as $ID) {
+        self::$_Reactions[$Type . $ID] = array();
+      }
+      // fill the cache
+      foreach ($Result as $Reaction) {
+        self::$_Reactions[$Type . $Reaction->ParentID][] = $Reaction;
+      }
+    }
   }
 
   /**

--- a/settings/class.hooks.php
+++ b/settings/class.hooks.php
@@ -541,12 +541,18 @@ class YagaHooks implements Gdn_IPlugin {
   }
 
   /**
-   * Insert JS and CSS files into the appropiate controllers
+   * Insert JS and CSS files into the appropiate controllers and fill the reaction cache
    * 
    * @param DiscussionController $Sender
    */
   public function DiscussionController_Render_Before($Sender) {
     $this->AddResources($Sender);
+    if (C('Yaga.Reactions.Enabled')) {
+      $CommentIDs = ConsolidateArrayValuesByKey($Sender->Data['Comments']->ResultArray(), 'CommentID');
+	  // set the DataSet type back to "object"
+      $Sender->Data['Comments']->DataSetType(DATASET_TYPE_OBJECT);
+      Yaga::ReactionModel()->Prefetch('comment', $CommentIDs);
+    }
   }
 
   /**

--- a/settings/class.hooks.php
+++ b/settings/class.hooks.php
@@ -549,7 +549,7 @@ class YagaHooks implements Gdn_IPlugin {
     $this->AddResources($Sender);
     if (C('Yaga.Reactions.Enabled')) {
       $CommentIDs = ConsolidateArrayValuesByKey($Sender->Data['Comments']->ResultArray(), 'CommentID');
-	  // set the DataSet type back to "object"
+      // set the DataSet type back to "object"
       $Sender->Data['Comments']->DataSetType(DATASET_TYPE_OBJECT);
       Yaga::ReactionModel()->Prefetch('comment', $CommentIDs);
     }

--- a/settings/class.hooks.php
+++ b/settings/class.hooks.php
@@ -547,7 +547,7 @@ class YagaHooks implements Gdn_IPlugin {
    */
   public function DiscussionController_Render_Before($Sender) {
     $this->AddResources($Sender);
-    if (C('Yaga.Reactions.Enabled')) {
+    if (C('Yaga.Reactions.Enabled') && isset($Sender->Data['Comments'])) {
       $CommentIDs = ConsolidateArrayValuesByKey($Sender->Data['Comments']->ResultArray(), 'CommentID');
       // set the DataSet type back to "object"
       $Sender->Data['Comments']->DataSetType(DATASET_TYPE_OBJECT);


### PR DESCRIPTION
This implements caching in the reaction model to reduce the number queries needed for the discussion view.

With 25 comments per page Yaga added up to 50 queries before. Now this is fixed to ~5.
