### PR TITLE
Figure out the correct file extension

### DIFF
--- a/controllers/class.badgecontroller.php
+++ b/controllers/class.badgecontroller.php
@@ -96,7 +96,7 @@ class BadgeController extends DashboardController {
 
       if($TmpImage) {
         // Generate the target image name
-        $TargetImage = $Upload->GenerateTargetName(PATH_UPLOADS);
+        $TargetImage = $Upload->GenerateTargetName(PATH_UPLOADS, FALSE);
         $ImageBaseName = pathinfo($TargetImage, PATHINFO_BASENAME);
 
         // Save the uploaded image

--- a/controllers/class.rankcontroller.php
+++ b/controllers/class.rankcontroller.php
@@ -51,7 +51,7 @@ class RankController extends DashboardController {
 
       if($TmpImage) {
         // Generate the target image name
-        $TargetImage = $Upload->GenerateTargetName(PATH_UPLOADS);
+        $TargetImage = $Upload->GenerateTargetName(PATH_UPLOADS, FALSE);
         $ImageBaseName = pathinfo($TargetImage, PATHINFO_BASENAME);
 
         // Save the uploaded image


### PR DESCRIPTION
Without a second parameter, GenerateTargetName will always pick .jpg:
https://github.com/vanilla/vanilla/blob/2.1/library/core/class.upload.php#L190

This in an alternative PR for #74 (people may want the badge images not to be re-saved / uncompressed)