### PR TITLE
Reduce memory consumption of ActedModel

### DIFF
--- a/models/class.actedmodel.php
+++ b/models/class.actedmodel.php
@@ -262,7 +262,7 @@ class ActedModel extends Gdn_Model {
 
     if($Content == Gdn_Cache::CACHEOP_FAILURE) {
 
-      $Discussions = Gdn::SQL()->Select('d.*, r.DateInserted as ReactionDate')
+      $Discussions = Gdn::SQL()->Select('d.DiscussionID, d.InsertUserID, d.CategoryID, r.DateInserted as ReactionDate')
                 ->From('Reaction r')
                 ->Where('ParentType', 'discussion')
                 ->Join('Discussion d', 'r.ParentID = d.DiscussionID')
@@ -270,7 +270,7 @@ class ActedModel extends Gdn_Model {
                 ->Get()
                 ->Result(DATASET_TYPE_ARRAY);
 
-      $Comments = Gdn::SQL()->Select('c.*, r.DateInserted as ReactionDate')
+      $Comments = Gdn::SQL()->Select('c.CommentID, c.InsertUserID, c.DiscussionID, r.DateInserted as ReactionDate')
                 ->From('Reaction r')
                 ->Where('ParentType', 'comment')
                 ->Join('Comment c', 'r.ParentID = c.CommentID')
@@ -365,7 +365,9 @@ class ActedModel extends Gdn_Model {
 
     foreach($Content as &$ContentItem) {
       $ContentType = strtolower(GetValue('ItemType', $ContentItem));
-      $ContentItem = array_merge($ContentItem, GetRecord($ContentType, $ContentItem[ucfirst($ContentType) . 'ID']));
+      $ItemID = $ContentItem[ucfirst($ContentType) . 'ID'];
+
+      $ContentItem = array_merge($ContentItem, $this->GetRecord($ContentType, $ItemID));
 
       $Replacement = array();
       $Fields = array('DiscussionID', 'CategoryID', 'DateInserted', 'DateUpdated', 'InsertUserID', 'Body', 'Format', 'ItemType');
@@ -436,6 +438,17 @@ class ActedModel extends Gdn_Model {
    */
   protected function CondenseAndPrep(&$Content, $Limit, $Offset) {
     $Content = (object) array('TotalRecords' => count($Content), 'Content' => array_slice($Content, $Offset, $Limit));
+  }
+
+  /**
+   * Wrapper for GetRecord()
+   *
+   * @param string $RecordType
+   * @param int $ID
+   * @return array
+   */
+  protected function GetRecord($RecordType, $ID) {
+    return GetRecord($RecordType, $ID);
   }
 
 }

--- a/models/class.actedmodel.php
+++ b/models/class.actedmodel.php
@@ -311,7 +311,7 @@ class ActedModel extends Gdn_Model {
     }
     $DiscussionIDs = array_keys($DiscussionIDs);
 
-    $Discussions = Gdn::SQL()->Select('d.*')
+    $Discussions = Gdn::SQL()->Select('d.DiscussionID, d.CategoryID, d.Name')
                     ->From('Discussion d')
                     ->WhereIn('DiscussionID', $DiscussionIDs)
                     ->Get()->Result(DATASET_TYPE_ARRAY);

--- a/models/class.actedmodel.php
+++ b/models/class.actedmodel.php
@@ -26,14 +26,14 @@ class ActedModel extends Gdn_Model {
   private function BaseSQL($Table = 'Discussion') {
     switch($Table) {
       case 'Comment':
-        $SQL = Gdn::SQL()->Select('c.*')
+        $SQL = Gdn::SQL()->Select('c.Score, c.CommentID, c.InsertUserID, c.DiscussionID, c.DateInserted')
                 ->From('Comment c')
                 ->Where('c.Score is not null')
                 ->OrderBy('c.Score', 'DESC');
         break;
       default:
       case 'Discussion':
-        $SQL = Gdn::SQL()->Select('d.*')
+        $SQL = Gdn::SQL()->Select('d.Score, d.DiscussionID, d.InsertUserID, d.CategoryID, d.DateInserted')
                 ->From('Discussion d')
                 ->Where('d.Score is not null')
                 ->OrderBy('d.Score', 'DESC');
@@ -83,7 +83,6 @@ class ActedModel extends Gdn_Model {
           'Discussion' => $Discussions,
           'Comment' => $Comments
       ));
-      $this->Prepare($Content);
 
       // Add result to cache
       Gdn::Cache()->Store($CacheKey, $Content, array(
@@ -93,6 +92,7 @@ class ActedModel extends Gdn_Model {
 
     $this->Security($Content);
     $this->CondenseAndPrep($Content, $Limit, $Offset);
+    $this->Prepare($Content->Content);
 
     return $Content;
   }
@@ -138,7 +138,6 @@ class ActedModel extends Gdn_Model {
           'Discussion' => $Discussions,
           'Comment' => $Comments
       ));
-      $this->Prepare($Content);
 
       // Add result to cache
       Gdn::Cache()->Store($CacheKey, $Content, array(
@@ -148,6 +147,7 @@ class ActedModel extends Gdn_Model {
 
     $this->Security($Content);
     $this->CondenseAndPrep($Content, $Limit, $Offset);
+    $this->Prepare($Content->Content);
 
     return $Content;
   }
@@ -190,7 +190,6 @@ class ActedModel extends Gdn_Model {
           'Discussion' => $Discussions,
           'Comment' => $Comments
       ));
-      $this->Prepare($Content);
 
       // Add result to cache
       Gdn::Cache()->Store($CacheKey, $Content, array(
@@ -200,6 +199,7 @@ class ActedModel extends Gdn_Model {
 
     $this->Security($Content);
     $this->CondenseAndPrep($Content, $Limit, $Offset);
+    $this->Prepare($Content->Content);
 
     return $Content;
   }
@@ -236,7 +236,6 @@ class ActedModel extends Gdn_Model {
           'Discussion' => $Discussions,
           'Comment' => $Comments
       ));
-      $this->Prepare($Content);
 
       Gdn::Cache()->Store($CacheKey, $Content, array(
           Gdn_Cache::FEATURE_EXPIRY => $this->_Expiry
@@ -245,6 +244,7 @@ class ActedModel extends Gdn_Model {
 
     $this->Security($Content);
     $this->CondenseAndPrep($Content, $Limit, $Offset);
+    $this->Prepare($Content->Content);
 
     return $Content;
   }
@@ -285,7 +285,6 @@ class ActedModel extends Gdn_Model {
           'Discussion' => $Discussions,
           'Comment' => $Comments
       ));
-      $this->Prepare($Content);
 
       Gdn::Cache()->Store($CacheKey, $Content, array(
           Gdn_Cache::FEATURE_EXPIRY => $this->_Expiry
@@ -294,6 +293,7 @@ class ActedModel extends Gdn_Model {
 
     $this->Security($Content);
     $this->CondenseAndPrep($Content, $Limit, $Offset);
+    $this->Prepare($Content->Content);
 
     return $Content;
   }
@@ -364,12 +364,13 @@ class ActedModel extends Gdn_Model {
   protected function Prepare(&$Content) {
 
     foreach($Content as &$ContentItem) {
-      $ContentType = GetValue('ItemType', $ContentItem);
+      $ContentType = strtolower(GetValue('ItemType', $ContentItem));
+      $ContentItem = array_merge($ContentItem, GetRecord($ContentType, $ContentItem[ucfirst($ContentType) . 'ID']));
 
       $Replacement = array();
       $Fields = array('DiscussionID', 'CategoryID', 'DateInserted', 'DateUpdated', 'InsertUserID', 'Body', 'Format', 'ItemType');
 
-      switch(strtolower($ContentType)) {
+      switch($ContentType) {
         case 'comment':
           $Fields = array_merge($Fields, array('CommentID'));
 


### PR DESCRIPTION
This patch makes the ActedModel only fetch columns that are needed for
sorting and security. All content is separately fetched by GetRecord().

Reduces the memory consumption of the ActedModel to ~ 1/5 but requires more queries and makes caching a little less efficient.

