### PR TITLE
ReactionModel: Remove check for allowed reaction types

### DIFF
--- a/models/class.reactionmodel.php
+++ b/models/class.reactionmodel.php
@@ -75,7 +75,7 @@ class ReactionModel extends Gdn_Model {
     if (array_key_exists($Type . $ID, self::$_Reactions)) {
       return self::$_Reactions[$Type . $ID];
     }
-    else if (in_array($Type, array('discussion', 'comment', 'activity')) && $ID > 0) {
+    else {
       $Result = $this->SQL
               ->Select('a.*, r.InsertUserID as UserID, r.DateInserted')
               ->From('Action a')
@@ -87,9 +87,6 @@ class ReactionModel extends Gdn_Model {
               ->Result();
       self::$_Reactions[$Type . $ID] = $Result;
       return $Result;
-    }
-    else {
-      return NULL;
     }
   }
 


### PR DESCRIPTION
- The checks are not needed
- Returning NULL throws a notice in foreach when passed into RenderReactionList/RenderReactionRecord
- This makes the ReactionModel more generic so it can be used with custom reaction types