### PR TITLE
Restrict message styles to BadgeController

### DIFF
--- a/design/yaga.css
+++ b/design/yaga.css
@@ -15,10 +15,10 @@
   max-width: 300px;
 }
 
-.Yaga .InfoMessage,
-.Yaga .AlertMessage,
-.Yaga .CasualMessage,
-.Yaga .WarningMessage {
+.Yaga.Badge .InfoMessage,
+.Yaga.Badge .AlertMessage,
+.Yaga.Badge .CasualMessage,
+.Yaga.Badge .WarningMessage {
   width: 240px;
   padding: 10px;
 }


### PR DESCRIPTION
Messages on Yaga frontend pages shouldn't be 240px wide.