### PR TITLE
Improve reaction caching

### DIFF
--- a/models/class.reactionmodel.php
+++ b/models/class.reactionmodel.php
@@ -223,6 +223,10 @@ class ReactionModel extends Gdn_Model {
    * @param array $IDs
    */
   public function Prefetch($Type, $IDs) {
+    if (!is_array($IDs)) {
+        $IDs = (array)$IDs;
+    }
+    
     if (in_array($Type, array('discussion', 'comment', 'activity')) && !empty($IDs)) {
       $Result = $this->SQL
         ->Select('a.*, r.InsertUserID as UserID, r.DateInserted, r.ParentID')
@@ -237,10 +241,16 @@ class ReactionModel extends Gdn_Model {
       foreach ($IDs as $ID) {
         self::$_Reactions[$Type . $ID] = array();
       }
+      
+      $UserIDs = array();
       // fill the cache
       foreach ($Result as $Reaction) {
+        $UserIDs[] = $Reaction->UserID;
         self::$_Reactions[$Type . $Reaction->ParentID][] = $Reaction;
       }
+
+      // Prime the user cache
+      Gdn::UserModel()->GetIDs($UserIDs);
     }
   }
 

--- a/settings/class.hooks.php
+++ b/settings/class.hooks.php
@@ -547,11 +547,16 @@ class YagaHooks implements Gdn_IPlugin {
    */
   public function DiscussionController_Render_Before($Sender) {
     $this->AddResources($Sender);
-    if (C('Yaga.Reactions.Enabled') && isset($Sender->Data['Comments'])) {
-      $CommentIDs = ConsolidateArrayValuesByKey($Sender->Data['Comments']->ResultArray(), 'CommentID');
-      // set the DataSet type back to "object"
-      $Sender->Data['Comments']->DataSetType(DATASET_TYPE_OBJECT);
-      Yaga::ReactionModel()->Prefetch('comment', $CommentIDs);
+    if (C('Yaga.Reactions.Enabled')) {
+      if ($Sender->Data('Discussion')) {
+        Yaga::ReactionModel()->Prefetch('discussion', $Sender->Data['Discussion']->DiscussionID);
+      }
+      if (isset($Sender->Data['Comments'])) {
+        $CommentIDs = ConsolidateArrayValuesByKey($Sender->Data['Comments']->ResultArray(), 'CommentID');
+        // set the DataSet type back to "object"
+        $Sender->Data['Comments']->DataSetType(DATASET_TYPE_OBJECT);
+        Yaga::ReactionModel()->Prefetch('comment', $CommentIDs);
+      }
     }
   }
   


### PR DESCRIPTION
The ReactionModel::Prefetch() method now also calls UserModel::GetIDs()
to fill the user cache with the associated UserIDs because the render
methods need these anyway.