### PR TITLE
Image Uploads: Use Asset root

### DIFF
--- a/controllers/class.badgecontroller.php
+++ b/controllers/class.badgecontroller.php
@@ -101,7 +101,8 @@ class BadgeController extends DashboardController {
 
         // Save the uploaded image
         $Parts = $Upload->SaveAs($TmpImage, 'yaga' . DS . $ImageBaseName);
-        $RelativeUrl = StringBeginsWith($Parts['Url'], Gdn_Url::WebRoot(TRUE), TRUE, TRUE);
+        $AssetRoot = Gdn::Request()->UrlDomain(TRUE).Gdn::Request()->AssetRoot();
+        $RelativeUrl = StringBeginsWith($Parts['Url'], $AssetRoot, TRUE, TRUE);
 
         $this->Form->SetFormValue('Photo', $RelativeUrl);
       }

--- a/controllers/class.rankcontroller.php
+++ b/controllers/class.rankcontroller.php
@@ -56,7 +56,8 @@ class RankController extends DashboardController {
 
         // Save the uploaded image
         $Parts = $Upload->SaveAs($TmpImage, 'yaga' . DS . $ImageBaseName);
-        $RelativeUrl = StringBeginsWith($Parts['Url'], Gdn_Url::WebRoot(TRUE), TRUE, TRUE);
+        $AssetRoot = Gdn::Request()->UrlDomain(TRUE).Gdn::Request()->AssetRoot();
+        $RelativeUrl = StringBeginsWith($Parts['Url'], $AssetRoot, TRUE, TRUE);
         SaveToConfig('Yaga.Ranks.Photo', $RelativeUrl);
 
         if(C('Yaga.Ranks.Photo') == $Parts['SaveName']) {


### PR DESCRIPTION
Requires Vanilla 2.2

When the asset root differs from the web root (ie when using the
StripPath config option), Yaga creates false upload urls.