### PR TITLE
NecroPost: Check for existence of DateLastComment

### DIFF
--- a/library/rules/class.necropost.php
+++ b/library/rules/class.necropost.php
@@ -19,7 +19,7 @@ class NecroPost implements YagaRule {
     $Discussion = $DiscussionModel->GetID($DiscussionID);
     $LastCommentDate = strtotime($Discussion->DateLastComment);
     
-    if($LastCommentDate < $NecroDate) {
+    if($Discussion->DateLastComment && $LastCommentDate < $NecroDate) {
       return TRUE;
     }
     else {


### PR DESCRIPTION
This fixes a bug where this badge will be awarded if no DateLastComment is set.