### PR TITLE
Change return Value of SetUserScore

### DIFF
--- a/models/class.reactionmodel.php
+++ b/models/class.reactionmodel.php
@@ -262,7 +262,7 @@ class ReactionModel extends Gdn_Model {
    * @param string $Type The type of the item (only supports 'discussion' and 'comment'
    * @param int $UserID The user that is scoring the item
    * @param int $Score What they give it
-   * @return boolean Whether or not the the request was successful
+   * @return int Total score if request was successful, FALSE if not.
    */
   private function SetUserScore($ID, $Type, $UserID, $Score) {
     $Model = FALSE;
@@ -278,8 +278,7 @@ class ReactionModel extends Gdn_Model {
     }
 
     if($Model) {
-      $Model->SetUserScore($ID, $UserID, $Score);
-      return TRUE;
+      return $Model->SetUserScore($ID, $UserID, $Score);
     }
     else {
       return FALSE;


### PR DESCRIPTION
Make SetUserScore() return value congruent to Vanillas Comment-/DiscussionModels methods.
By now there is an if($Model) return True, else return FALSE construct in order to handle failures. Simply changing it the way I have done it would be very risky, since a `if SetUserScore(...) == 0` would require a `===` to be reliable.
Maybe some exception or logging would be better for failures.
