### PR TITLE
Add TotalScore to event AfterReactionSave

### DIFF
--- a/models/class.reactionmodel.php
+++ b/models/class.reactionmodel.php
@@ -208,7 +208,8 @@ class ReactionModel extends Gdn_Model {
     }
 
     // Update the parent item score
-    $this->SetUserScore($ID, $Type, $UserID, $Score);
+    $TotalScore = $this->SetUserScore($ID, $Type, $UserID, $Score);
+    $EventArgs['TotalScore'] = $TotalScore;
     // Give the user points commesurate with reaction activity
     Yaga::GivePoints($AuthorID, $Points, 'Reaction');
     $EventArgs['Points'] = $Points;


### PR DESCRIPTION
This would only work if SetUserScore returns the TotalScore, which is possible since that value is returned by Vanillas SetUserScore methods. I've tried a PR for that: https://github.com/hgtonight/Application-Yaga/pull/132 but I'm not too happy with how it is done (see there)
