### PR TITLE
Match declarations of parent class 

### DIFF
--- a/controllers/class.badgecontroller.php
+++ b/controllers/class.badgecontroller.php
@@ -167,7 +167,7 @@ class BadgeController extends DashboardController {
     $this->Permission('Yaga.Badges.Manage');
 
     if($this->Form->IsPostBack()) {
-      if(!$this->BadgeModel->Delete($BadgeID)) {
+      if(!$this->BadgeModel->DeleteID($BadgeID)) {
         $this->Form->AddError(sprintf(T('Yaga.Error.DeleteFailed'), T('Yaga.Badge')));
       }
 

--- a/controllers/class.rankcontroller.php
+++ b/controllers/class.rankcontroller.php
@@ -167,7 +167,7 @@ class RankController extends DashboardController {
     $this->Permission('Yaga.Ranks.Manage');
 
     if($this->Form->IsPostBack()) {
-      if(!$this->RankModel->Delete($RankID)) {
+      if(!$this->RankModel->DeleteID($RankID)) {
         $this->Form->AddError(sprintf(T('Yaga.Error.DeleteFailed'), T('Yaga.Rank')));
       }
 

--- a/models/class.badgemodel.php
+++ b/models/class.badgemodel.php
@@ -30,13 +30,10 @@ class BadgeModel extends Gdn_Model {
    *
    * @return DataSet
    */
-  public function Get() {
+  public function Get($OrderFields = 'Sort', $OrderDirection = 'asc', $Limit = false, $PageNumber = false) {
     if(empty(self::$_Badges)) {
-      self::$_Badges = $this->SQL
-              ->Select()
-              ->From('Badge')
-              ->OrderBy('Sort')
-              ->Get()
+      self::$_Badges = $this->
+              ->Get($OrderFields, $OrderDirection, $Limit, $PageNumber)
               ->Result();
     }
     return self::$_Badges;
@@ -63,8 +60,8 @@ class BadgeModel extends Gdn_Model {
    * Total number of badges in the system
    * @return int
    */
-  public function GetCount() {
-    return count($this->Get());
+  public function GetCount($Wheres = '') {
+    return count($this->GetWhere($Wheres));
   }
 
   /**
@@ -108,7 +105,7 @@ class BadgeModel extends Gdn_Model {
    * @throws Exception
    * @return boolean
    */
-  public function Delete($BadgeID) {
+  public function DeleteID($BadgeID, $Options = []) {
     $Badge = $this->GetByID($BadgeID);
     if(!empty($Badge)) {
       try {

--- a/models/class.badgemodel.php
+++ b/models/class.badgemodel.php
@@ -32,7 +32,7 @@ class BadgeModel extends Gdn_Model {
    */
   public function Get($OrderFields = 'Sort', $OrderDirection = 'asc', $Limit = false, $PageNumber = false) {
     if(empty(self::$_Badges)) {
-      self::$_Badges = $this->
+      self::$_Badges = $this
               ->Get($OrderFields, $OrderDirection, $Limit, $PageNumber)
               ->Result();
     }

--- a/models/class.rankmodel.php
+++ b/models/class.rankmodel.php
@@ -36,13 +36,10 @@ class RankModel extends Gdn_Model {
    *
    * @return DataSet
    */
-  public function Get() {
+  public function Get($OrderFields = 'Sort', $OrderDirection = 'asc', $Limit = false, $PageNumber = false) {
     if(empty(self::$_Ranks)) {
-      self::$_Ranks = $this->SQL
-              ->Select()
-              ->From('Rank')
-              ->OrderBy('Sort')
-              ->Get()
+      self::$_Ranks = $this
+              ->Get($OrderFields, $OrderDirection, $Limit, $PageNumber)
               ->Result();
     }
     return self::$_Ranks;
@@ -53,8 +50,8 @@ class RankModel extends Gdn_Model {
    * 
    * @return int
    */
-  public function GetCount() {
-    return count($this->Get());
+  public function GetCount($Wheres = '') {
+    return count($this->GetWhere($Wheres));
   }
 
   /**
@@ -174,7 +171,7 @@ class RankModel extends Gdn_Model {
    * @param int $RankID
    * @return boolean
    */
-  public function Delete($RankID) {
+  public function DeleteID($RankID, $Options = []) {
     $Rank = $this->GetByID($RankID);
     if($Rank) {
       $this->SQL->Delete('Rank', array('RankID' => $RankID));


### PR DESCRIPTION
These model methods throw warnings under PHP7, because they violate substitutability :

* `Get` (which now `Gdn_Model::get()`)
* `GetCount`, which should take a `$Where`
* `Delete`, which should actually be `DeleteID` anyway, because it only deletes a single row.