### PR TITLE
Restore rank specific custom configs in settings controller

### DIFF
--- a/settings/class.hooks.php
+++ b/settings/class.hooks.php
@@ -542,6 +542,7 @@ class YagaHooks implements Gdn_IPlugin {
    * @param mixed $Value
    */
   private function ApplyCustomConfigs($Name = NULL, $Value = NULL) {
+    SaveToConfig('Yaga.ConfBackup.'.$Name, C($Name, null), array('Save' => FALSE));
     SaveToConfig($Name, $Value, array('Save' => FALSE));
   }
 
@@ -864,5 +865,25 @@ class YagaHooks implements Gdn_IPlugin {
     include(CombinePaths(array(PATH_APPLICATIONS . DS . 'yaga' . DS . 'settings' . DS . 'about.php')));
     $Version = ArrayValue('Version', ArrayValue('Yaga', $ApplicationInfo, array()), 'Undefined');
     SaveToConfig('Yaga.Version', $Version);
+  }
+
+  /**
+   * Restore rank specific custom configs to site defaults.
+   *
+   * The rank feature allows custom config settings. In order to show divergent
+   * site settings correctly, those custom config settings have to be replaced
+   * by the original ones.
+   *
+   * @param SettingsController $Sender Instance of the calling class.
+   *
+   * @return void.
+   */
+  public function SettingsController_Render_Before($Sender) {
+    // If Ranks feature isn't used, there's nothing to do here.
+    if(!C('Yaga.Ranks.Enabled') == true) {
+      return;
+    }
+    // Restore backed up configs.
+    Gdn::config()->loadArray(C('Yaga.ConfBackup'));
   }
 }


### PR DESCRIPTION
This is a solution for https://github.com/hgtonight/Application-Yaga/issues/139

Config settings which are changed by rank specific settings were still changed when looking at those settings in the methods of the SettingsController. So what was shown in dashboard were not the site specific settings, but the user specific settings.

This PR temporarily saves a "backup" of the changed settings (`SaveToConfig(..., false)`) and re-applies those backed up config settings in `SettingsController_Before_Render()`
