### PR TITLE
Fix/input prefix depreciation

### DIFF
--- a/controllers/class.badgecontroller.php
+++ b/controllers/class.badgecontroller.php
@@ -14,6 +14,8 @@ class BadgeController extends DashboardController {
    * $this->ObjectName
    */
   public $Uses = array('Form', 'BadgeModel', 'BadgeAwardModel');
+  
+  private $EditFormFields = ['TransientKey', 'hpt', 'BadgeID', 'Name', 'Description', 'RuleClass', 'AwardValue', 'Checkboxes', 'Save', 'Enabled'];
 
   /**
    * Make this look like a dashboard page and add the resources
@@ -114,13 +116,7 @@ class BadgeController extends DashboardController {
 
       // Find the rule criteria
       $FormValues = $this->Form->FormValues(); 
-      $Criteria = array();
-      foreach($FormValues as $Key => $Value) {
-        if(substr($Key, 0, 7) == '_Rules/') {
-          $RealKey = substr($Key, 7);
-          $Criteria[$RealKey] = $Value;
-        }
-      }
+      $Criteria = array_diff_key($FormValues, array_flip($this->EditFormFields));
 
       // Validate the criteria
       $RuleClass = new $FormValues['RuleClass'];

--- a/controllers/class.badgecontroller.php
+++ b/controllers/class.badgecontroller.php
@@ -113,7 +113,7 @@ class BadgeController extends DashboardController {
       }
 
       // Find the rule criteria
-      $FormValues = $this->Form->FormValues();     
+      $FormValues = $this->Form->FormValues(); 
       $Criteria = array();
       foreach($FormValues as $Key => $Value) {
         if(substr($Key, 0, 7) == '_Rules/') {

--- a/views/badge/edit.php
+++ b/views/badge/edit.php
@@ -1,7 +1,7 @@
 <?php if(!defined('APPLICATION')) exit();
 /* Copyright 2013 Zachary Doll */
 
-// Gnab the rules so we can render the first criteria form by default
+// Grab the rules so we can render the first criteria form by default
 $Rules = RulesController::GetRules();
 $RuleClass = key($Rules);
 

--- a/views/badge/edit.php
+++ b/views/badge/edit.php
@@ -60,14 +60,9 @@ echo $this->Form->Errors();
     ?>
   </li>
   <li id="Rule-Criteria">
-  <?php
-    // Save the Prefix for later
-    $Prefix = $this->Form->InputPrefix;
-    $this->Form->InputPrefix = $Prefix . '_Rules';
+    <?php
     echo $Rule->Form($this->Form);
-    // Restore the prefix
-    $this->Form->InputPrefix = $Prefix;
-  ?>
+    ?>
   </li>
   <li>
     <?php


### PR DESCRIPTION
The InputPrefix method of the form class allowed to use something like "namespaces" for form elements. That feature has been removed and without changing the workload for writing custom rules or changing more logic in your application, a simple blacklist of all fields that are not used for the rule but for the general form seems to be quite a pragmatic solution.