### PR TITLE
Substitute Form->InputPrefix usage

### DIFF
--- a/controllers/class.rankcontroller.php
+++ b/controllers/class.rankcontroller.php
@@ -109,26 +109,33 @@ class RankController extends DashboardController {
     }
     else {
       // Find the perk options
-      $FormValues = $this->Form->FormValues();     
-      $PerkOptions = array();
-      foreach($FormValues as $Key => $Value) {
-        // Don't save default settings
-        if($Value === '') {
-          continue;
-        }
-        
-        if(substr($Key, 0, 7) == '_Perks/') {
-          $RealKey = substr($Key, 7);
-          $PerkOptions[$RealKey] = $Value;
-        }
-      }
+      $PerkOptions = array_intersect_key(
+        $this->Form->FormValues(),
+        array_flip(
+          [
+            'ConfGarden.EditContentTimeout',
+            'ConfGarden.Format.MeActions',
+            'ConfPlugins.Emotify.FormatEmoticons',
+            'ConfYaga.Perks.EditTimeout',
+            'ConfYaga.Perks.Emoticons',
+            'ConfYaga.Perks.MeActions',
+            'PermGarden.Curation.Manage',
+            'PermPlugins.Signatures.Edit',
+            'PermPlugins.Tagging.Add',
+            'PermYaga.Perks.Curation',
+            'PermYaga.Perks.Signatures',
+            'PermYaga.Perks.Tags',
+            'Role'
+          ]
+        )
+      );
 
       // Fire event for validating perk options
       $this->EventArguments['PerkOptions'] =& $PerkOptions;
       $this->FireEvent('BeforeValidation');
-      
+
       $this->Form->SetFormValue('Perks', serialize($PerkOptions));
-      
+
       if($this->Form->Save()) {
         if($Edit) {
           $this->InformMessage(T('Yaga.Rank.Updated'));

--- a/controllers/class.rulescontroller.php
+++ b/controllers/class.rulescontroller.php
@@ -104,7 +104,6 @@ class RulesController extends Gdn_Controller {
     if(class_exists($RuleClass) && in_array('YagaRule', class_implements($RuleClass))) {
       $Rule = new $RuleClass();
       $Form = Gdn::Factory('Form');
-      $Form->InputPrefix = '_Rules';
       $FormString = $Rule->Form($Form);
       $Description = $Rule->Description();
       $Name = $Rule->Name();

--- a/views/rank/edit.php
+++ b/views/rank/edit.php
@@ -48,13 +48,8 @@ echo $this->Form->Errors();
   echo Wrap(T('Yaga.Perks'), 'h3');
 ?>
 <ul>
-  <?php
-    // Save the Prefix for later
-    $Prefix = $this->Form->InputPrefix;
-    $this->Form->InputPrefix = $Prefix . '_Perks';
-    ?>
   <li>
-    <?php    
+    <?php
     echo $this->Form->Label('Role', 'Role');
     echo $this->Form->Dropdown('Role', $this->Data('Roles'), array('IncludeNULL' => TRUE));
     ?>
@@ -62,8 +57,8 @@ echo $this->Form->Errors();
   <li>
   <?php
   echo RenderPerkConfigurationForm('Garden.EditContentTimeout', 'Yaga.Perks.EditTimeout', array('0' => T('Authors may never edit'),
-                      '350' => sprintf(T('Authors may edit for %s'), T('5 minutes')), 
-                      '900' => sprintf(T('Authors may edit for %s'), T('15 minutes')), 
+                      '350' => sprintf(T('Authors may edit for %s'), T('5 minutes')),
+                      '900' => sprintf(T('Authors may edit for %s'), T('15 minutes')),
                      '3600' => sprintf(T('Authors may edit for %s'), T('1 hour')),
                     '14400' => sprintf(T('Authors may edit for %s'), T('4 hours')),
                     '86400' => sprintf(T('Authors may edit for %s'), T('1 day')),
@@ -99,9 +94,6 @@ echo $this->Form->Errors();
   </li>
   <?php
   $this->FireEvent('PerkOptions');
-
-  // Restore the prefix
-  $this->Form->InputPrefix = $Prefix;
   ?>
 </ul>
 <?php


### PR DESCRIPTION
The InputPrefix is deprecated and abandoned in Vanilla 2.3. It is a follow up to https://github.com/hgtonight/Application-Yaga/pull/148

Thanks to @HIAviator for the hint.