### PR TITLE
Activity photos should not have absolute paths.

### DIFF
--- a/models/class.badgeawardmodel.php
+++ b/models/class.badgeawardmodel.php
@@ -93,7 +93,7 @@ class BadgeAwardModel extends Gdn_Model {
             'ActivityType' => 'BadgeAward',
             'ActivityUserID' => $UserID,
             'RegardingUserID' => $InsertUserID,
-            'Photo' => Url($Badge->Photo, TRUE),
+            'Photo' => $Badge->Photo,
             'RecordType' => 'Badge',
             'RecordID' => $BadgeID,
             'Route' => '/yaga/badges/' . $Badge->BadgeID . '/' . Gdn_Format::Url($Badge->Name),


### PR DESCRIPTION
 Not portable and can cause mixed content errors over https

https://github.com/hgtonight/Application-Yaga/issues/117