### PR TITLE
Switch dd / dt for badge count in profile

### DIFF
--- a/settings/class.hooks.php
+++ b/settings/class.hooks.php
@@ -124,8 +124,8 @@ class YagaHooks implements Gdn_IPlugin {
    */
   public function UserInfoModule_OnBasicInfo_Handler($Sender) {
     if(C('Yaga.Badges.Enabled')) {
-      echo '<dd class="Badges">' . $Sender->User->CountBadges . '</dd>';
       echo '<dt class="Badges">' . T('Yaga.Badges', 'Badges') . '</dt> ';
+      echo '<dd class="Badges">' . $Sender->User->CountBadges . '</dd>';
     }
   }
 


### PR DESCRIPTION
This just makes Yagas badge count similar to how the rest of the definition list is rendered (dt before dd).
e.g. see https://open.vanillaforums.com/profile/Bleistivt