### PR TITLE
Set legacy style for frontend facing view

### DIFF
--- a/views/badge/award.php
+++ b/views/badge/award.php
@@ -4,6 +4,8 @@
 $Badges = $this->Data('Badges');
 $Username = $this->Data('Username', 'Unknown');
 
+$this->Form->setStyles('legacy');
+
 echo '<div id="UserBadgeForm">';
 echo Wrap(sprintf(T('Yaga.Badge.GiveTo'), $Username), 'h1');
 echo $this->Form->Open();


### PR DESCRIPTION
Since the dashboard forms use different CSS classes now (and BadgeController extends DashboardController), the award view needs non-dashboard styling.

I have done something similar in my UnawardBadge-plugin:
https://github.com/bleistivt/YagaUnawardBadge/commit/f422fa

I'm not sure if this directive belongs in the view, as it is not used on a case-by-case basis in core:
https://github.com/vanilla/vanilla/search?q=setStyles

But I felt it fit in the view since it concerns styling only.